### PR TITLE
Prevents PHPUnit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,11 @@
         "pestphp/pest": "^1.21",
         "symfony/var-dumper": "^5.3"
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "pestphp/pest-plugin": true
+        }
+    }
 }

--- a/src/WorksomeSniff/Sniffs/Classes/DisallowPHPUnitTestsSniff.php
+++ b/src/WorksomeSniff/Sniffs/Classes/DisallowPHPUnitTestsSniff.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\WorksomeSniff\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+final class DisallowPHPUnitTestsSniff implements Sniff
+{
+    public string $testSuffix = 'Test';
+
+    /**
+     * @var array<int, string>
+     */
+    public array $testDirectories = [
+        'tests'
+    ];
+
+    public function register(): array
+    {
+        return [T_CLASS];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (! str_ends_with($phpcsFile->getFilename(), $this->testSuffix . '.php')) {
+            return;
+        }
+
+        if (! $this->fileIsInTestDirectories($phpcsFile)) {
+            return;
+        }
+
+        $classNamePointer = $stackPtr + 2;
+        $className = $phpcsFile->getTokensAsString($classNamePointer, 1);
+
+        if (! str_ends_with($className, $this->testSuffix)) {
+            return;
+        }
+
+        if ($phpcsFile->findExtendedClassName($stackPtr) === false) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'PHPUnit tests are not allowed. Please use Pest PHP instead.',
+            $classNamePointer,
+            self::class,
+        );
+    }
+
+    private function fileIsInTestDirectories(File $phpcsFile): bool
+    {
+        foreach ($this->testDirectories as $testDirectory) {
+            if (str_contains($phpcsFile->getFilename(), $testDirectory)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/tests/Resources/Sniffs/Classes/DisallowPHPUnitTestsSniff/TestOutsideOfTestDirectoryTest.php
+++ b/tests/Resources/Sniffs/Classes/DisallowPHPUnitTestsSniff/TestOutsideOfTestDirectoryTest.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Worksome\WorksomeSniff\Tests\Resources\Sniffs\Classes\DisallowPHPUnitTestsSniff;
+
+use PHPUnit\Framework\TestCase;
+
+class TestOutsideOfTestDirectoryTest extends TestCase
+{
+
+}

--- a/tests/Resources/Sniffs/Classes/DisallowPHPUnitTestsSniff/tests/SomePhpUnitTest.php
+++ b/tests/Resources/Sniffs/Classes/DisallowPHPUnitTestsSniff/tests/SomePhpUnitTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Worksome\WorksomeSniff\Tests\Resources\Sniffs\Classes\DisallowPHPUnitTestsSniff\tests;
+
+class SomePhpUnitTest extends TestCase
+{
+
+}

--- a/tests/Resources/Sniffs/Classes/DisallowPHPUnitTestsSniff/tests/SomeRandomClassThatDoesNotExtendTestCaseButEndsInTest.php
+++ b/tests/Resources/Sniffs/Classes/DisallowPHPUnitTestsSniff/tests/SomeRandomClassThatDoesNotExtendTestCaseButEndsInTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Worksome\WorksomeSniff\Tests\Resources\Sniffs\Classes\DisallowPHPUnitTestsSniff\tests;
+
+class SomeRandomClassThatDoesNotExtendTestCaseButEndsInTest
+{
+
+}

--- a/tests/Resources/Sniffs/Classes/DisallowPHPUnitTestsSniff/tests/TestCase.php
+++ b/tests/Resources/Sniffs/Classes/DisallowPHPUnitTestsSniff/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Worksome\WorksomeSniff\Tests\Resources\Sniffs\Classes\DisallowPHPUnitTestsSniff\tests;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+
+}

--- a/tests/Resources/Sniffs/Classes/DisallowPHPUnitTestsSniff/tests/TraitTest.php
+++ b/tests/Resources/Sniffs/Classes/DisallowPHPUnitTestsSniff/tests/TraitTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Worksome\WorksomeSniff\Tests\Resources\Sniffs\Classes\DisallowPHPUnitTestsSniff\tests;
+
+trait TraitTest
+{
+
+}

--- a/tests/Sniffs/Classes/DisallowPHPUnitTestsSniff.php
+++ b/tests/Sniffs/Classes/DisallowPHPUnitTestsSniff.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Worksome\WorksomeSniff\Tests\Sniffs\Classes;
+
+use SlevomatCodingStandard\Sniffs\TestCase;
+use Worksome\WorksomeSniff\Sniffs\Classes\DisallowPHPUnitTestsSniff;
+use Worksome\WorksomeSniff\Sniffs\Classes\ExceptionSuffixSniff;
+
+beforeEach(function () {
+    $this->sniff = DisallowPHPUnitTestsSniff::class;
+});
+
+it('has no errors', function (string $path) {
+    $report = checkFile($path, [
+        'testDirectories' => [__DIR__ . '/../../Resources/Sniffs/Classes/DisallowPHPUnitTestsSniff/tests']
+    ]);
+
+    expect($report)->toHaveNoSniffErrors();
+})->with([
+    'File outside of test directories' => __DIR__ . '/../../Resources/Sniffs/Classes/DisallowPHPUnitTestsSniff/TestOutsideOfTestDirectoryTest.php',
+    'Trait ending with "Test" suffix' => __DIR__ . '/../../Resources/Sniffs/Classes/DisallowPHPUnitTestsSniff/tests/TraitTest.php',
+    'Test that does not end with "Test" suffix' => __DIR__ . '/../../Resources/Sniffs/Classes/DisallowPHPUnitTestsSniff/tests/TestCase.php',
+    'Random class that ends with "Test" suffix' => __DIR__ . '/../../Resources/Sniffs/Classes/DisallowPHPUnitTestsSniff/tests/SomeRandomClassThatDoesNotExtendTestCaseButEndsInTest.php',
+]);
+
+it('has errors', function (string $path, int $line) {
+    $report = checkFile($path);
+
+    expect($report)
+        ->toHaveSniffErrors(1)
+        ->toHaveSniffError(line: $line);
+})->with([
+    'class ending with "Test" suffix' => [
+        __DIR__ . '/../../Resources/Sniffs/Classes/DisallowPHPUnitTestsSniff/tests/SomePhpUnitTest.php',
+        5
+    ]
+]);


### PR DESCRIPTION
This PR aims to prevent PHPUnit tests in the codebase. I've opted for the following rules:

A class is a PHPUnit test if it:

1. Is inside the configured test directory (`tests` by default)
2. Is a class
3. Has a filename ending in the configured suffix (`Test.php` by default)
4. Has a classname ending in the configured suffix (`Test` by default)
5. Extends a class 

Test directories can be configured using the `testDirectories` array and the suffix can be configured using the `testSuffix` string.