### PR TITLE
Added ray() to list of forbidden functions

### DIFF
--- a/src/WorksomeSniff/ruleset.xml
+++ b/src/WorksomeSniff/ruleset.xml
@@ -11,6 +11,7 @@
                 <element key="c" value="null"/>
                 <element key="var_dump" value="null"/>
                 <element key="ddd" value="null"/>
+                <element key="ray" value="null"/>
             </property>
         </properties>
     </rule>


### PR DESCRIPTION
We should not leave calls to ray() in the code.