### PR TITLE
fix: add support for more basic types

### DIFF
--- a/src/WorksomeSniff/Support/PropertyDoc.php
+++ b/src/WorksomeSniff/Support/PropertyDoc.php
@@ -76,7 +76,7 @@ final class PropertyDoc
         return <<<REGEXP
         /
         (                                       # Capture group #1.
-            [$\\\\\w]+                              # Match any word, including words with '$' or '\' symbols.
+            [$\\\\\w-]+                           # Match any word, including words with '$', '\', or '-' symbols.
             (                                   # Capture group #2.
                 [\[{<]                            # Match any '<' or '{' symbols, which are used in PHPStan generics.
                 (?:[^\[\]{}<>]+|(?2))*+             # Recursively ignore any matching sets of '<' and '>', '{' and '}' or '[' and ']' found in nested types. Eg: `Collection<int, array<string, string>>`.

--- a/tests/Resources/Sniffs/PhpDoc/PropertyDollarSignSniff/Fixed/InvalidProperties.php.fixed
+++ b/tests/Resources/Sniffs/PhpDoc/PropertyDollarSignSniff/Fixed/InvalidProperties.php.fixed
@@ -10,6 +10,8 @@ namespace Worksome\WorksomeSniff\Tests\Resources\Sniffs\PhpDoc\PropertyDollarSig
  * @property array{foo: string, bar: array<int, string>} | null $bam This is a collection
  * @property-read $foo
  * @property string[] $whoops
+ * @property positive-int $nice_int
+ * @property non-empty-array<\Exception> $non_empty_array
  */
 class InvalidProperties
 {

--- a/tests/Resources/Sniffs/PhpDoc/PropertyDollarSignSniff/InvalidProperties.php
+++ b/tests/Resources/Sniffs/PhpDoc/PropertyDollarSignSniff/InvalidProperties.php
@@ -10,6 +10,8 @@ namespace Worksome\WorksomeSniff\Tests\Resources\Sniffs\PhpDoc\PropertyDollarSig
  * @property array{foo: string, bar: array<int, string>} | null bam This is a collection
  * @property-read foo
  * @property string[] whoops
+ * @property positive-int nice_int
+ * @property non-empty-array<\Exception> non_empty_array
  */
 class InvalidProperties
 {

--- a/tests/Sniffs/PhpDoc/PropertyDollarSignSniffTest.php
+++ b/tests/Sniffs/PhpDoc/PropertyDollarSignSniffTest.php
@@ -31,7 +31,7 @@ it('has errors', function (string $path, array $lines) {
 })->with([
     'invalid properties' => [
         __DIR__ . '/../../Resources/Sniffs/PhpDoc/PropertyDollarSignSniff/InvalidProperties.php',
-        [6, 7, 8, 9, 10, 11, 12],
+        [6, 7, 8, 9, 10, 11, 12, 13, 14],
     ],
 ]);
 


### PR DESCRIPTION
This adds support for additional basic types such as `positive-int` and `non-empty-array` which were previously failing due to `-` not being a supported character in the type.