### PR TITLE
feat: JIRA-6316 Adds rule to disallow TODO's

### DIFF
--- a/src/WorksomeSniff/Sniffs/Comments/DisallowTodoCommentsSniff.php
+++ b/src/WorksomeSniff/Sniffs/Comments/DisallowTodoCommentsSniff.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Worksome\WorksomeSniff\Sniffs\Comments;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class DisallowTodoCommentsSniff implements Sniff
+{
+    public function register(): array
+    {
+        return [
+            T_COMMENT,
+            T_DOC_COMMENT_TAG,
+            T_DOC_COMMENT_STRING,
+        ];
+    }
+
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Check if TODO
+        dump($phpcsFile->getTokensAsString($stackPtr, 1));
+        if (stripos($phpcsFile->getTokensAsString($stackPtr, 1), 'TODO') === false) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            "Comments with TODO are disallowed",
+            $stackPtr,
+            self::class
+        );
+    }
+}

--- a/tests/Resources/Sniffs/Comments/DisallowTodoCommentsSniff/CommentWithTodoLower.php
+++ b/tests/Resources/Sniffs/Comments/DisallowTodoCommentsSniff/CommentWithTodoLower.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Worksome\WorksomeSniff\Tests\Resources\Sniffs\Comments\DisallowTodoCommentsSniff;
+
+class CommentWithTodoLower
+{
+    public function someMethod(): void
+    {
+        // todo is not allowed
+    }
+}

--- a/tests/Resources/Sniffs/Comments/DisallowTodoCommentsSniff/CommentWithTodoMixed.php
+++ b/tests/Resources/Sniffs/Comments/DisallowTodoCommentsSniff/CommentWithTodoMixed.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Worksome\WorksomeSniff\Tests\Resources\Sniffs\Comments\DisallowTodoCommentsSniff;
+
+class CommentWithTodoMixed
+{
+    public function someMethod(): void
+    {
+        // ToDo is not allowed
+    }
+}

--- a/tests/Resources/Sniffs/Comments/DisallowTodoCommentsSniff/CommentWithTodoUpper.php
+++ b/tests/Resources/Sniffs/Comments/DisallowTodoCommentsSniff/CommentWithTodoUpper.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Worksome\WorksomeSniff\Tests\Resources\Sniffs\Comments\DisallowTodoCommentsSniff;
+
+class CommentWithTodoUpper
+{
+    public function someMethod(): void
+    {
+        // TODO is not allowed
+    }
+}

--- a/tests/Resources/Sniffs/Comments/DisallowTodoCommentsSniff/CommentWithoutTodo.php
+++ b/tests/Resources/Sniffs/Comments/DisallowTodoCommentsSniff/CommentWithoutTodo.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Worksome\WorksomeSniff\Tests\Resources\Sniffs\Comments\DisallowTodoCommentsSniff;
+
+class CommentWithoutTodo
+{
+    public function someMethod(): void
+    {
+        // Comment is allowed
+    }
+}

--- a/tests/Resources/Sniffs/Comments/DisallowTodoCommentsSniff/PhpdocWithTodo.php
+++ b/tests/Resources/Sniffs/Comments/DisallowTodoCommentsSniff/PhpdocWithTodo.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Worksome\WorksomeSniff\Tests\Resources\Sniffs\Comments\DisallowTodoCommentsSniff;
+
+class PhpdocWithTodo
+{
+    /**
+     * TODO phpdoc not allowed
+     *
+     * @return void
+     */
+    public function someMethod(): void
+    {
+    }
+}

--- a/tests/Resources/Sniffs/Comments/DisallowTodoCommentsSniff/PhpdocWithTodoTag.php
+++ b/tests/Resources/Sniffs/Comments/DisallowTodoCommentsSniff/PhpdocWithTodoTag.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Worksome\WorksomeSniff\Tests\Resources\Sniffs\Comments\DisallowTodoCommentsSniff;
+
+class PhpdocWithTodoTag
+{
+    /**
+     * @TODO phpdoc not allowed
+     *
+     * @return void
+     */
+    public function someMethod(): void
+    {
+    }
+}

--- a/tests/Sniffs/Comments/DisallowTodoCommentsTest.php
+++ b/tests/Sniffs/Comments/DisallowTodoCommentsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Worksome\WorksomeSniff\Tests\Sniffs\Comments;
+
+use Worksome\WorksomeSniff\Sniffs\Comments\DisallowTodoCommentsSniff;
+
+beforeEach(function () {
+    $this->sniff = DisallowTodoCommentsSniff::class;
+});
+
+it('has no errors', function (string $path) {
+    $report = checkFile($path);
+
+    expect($report)->toHaveNoSniffErrors();
+})->with([
+    'comment without todo' => __DIR__ . '/../../Resources/Sniffs/Comments/DisallowTodoCommentsSniff/CommentWithoutTodo.php',
+]);
+
+it('has errors', function (string $path, int $line) {
+    $report = checkFile($path);
+
+    expect($report)
+        ->toHaveSniffErrors(1)
+        ->toHaveSniffError(line: $line);
+})->with([
+    'comment with todo upper' => [__DIR__ . '/../../Resources/Sniffs/Comments/DisallowTodoCommentsSniff/CommentWithTodoUpper.php', 9],
+    'comment with todo lower' => [__DIR__ . '/../../Resources/Sniffs/Comments/DisallowTodoCommentsSniff/CommentWithTodoLower.php', 9],
+    'comment with todo mixed' => [__DIR__ . '/../../Resources/Sniffs/Comments/DisallowTodoCommentsSniff/CommentWithTodoMixed.php', 9],
+    'phpdoc with todo tag' => [__DIR__ . '/../../Resources/Sniffs/Comments/DisallowTodoCommentsSniff/PhpdocWithTodoTag.php', 8],
+    'phpdoc with todo' => [__DIR__ . '/../../Resources/Sniffs/Comments/DisallowTodoCommentsSniff/PhpdocWithTodo.php', 8],
+]);


### PR DESCRIPTION
This adds a `DisallowTodoCommentsSniff` to report on comments and phpdoc that contain the word TODO (any case).