### PR TITLE
chore(deps): bump `slevomat/coding-standard` to ^8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "PHP": "^8.0",
         "squizlabs/php_codesniffer": "^3.6.1",
-        "slevomat/coding-standard": "^7.0",
+        "slevomat/coding-standard": "^8.5",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "thecodingmachine/safe": "^2.0",
         "illuminate/support": "^8.78 || ^9.0",


### PR DESCRIPTION
This is required for intersection type support in PHP 8.1 👍🏻