### PR TITLE
fix: rename rule reference and remove duplicates

### DIFF
--- a/src/WorksomeSniff/ruleset.xml
+++ b/src/WorksomeSniff/ruleset.xml
@@ -67,7 +67,7 @@
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
     <rule ref="SlevomatCodingStandard.PHP.ShortList"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHintSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.PropertyDeclaration"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
     <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
     <rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>
@@ -105,8 +105,5 @@
             </property>
         </properties>
     </rule>
-    <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHintSpacing"/>
     <rule ref="PSR12"/>
 </ruleset>


### PR DESCRIPTION
This renames `SlevomatCodingStandard.TypeHints.PropertyTypeHintSpacing` to `SlevomatCodingStandard.Classes.PropertyDeclaration`, which was a breaking change in v8.x that I didn't see. 🤦🏻

There are also 3 rules that are duplicated, I've removed the duplicates, but happy to put them back if they were intentional. 🤷🏻